### PR TITLE
Detect windows platform by using python

### DIFF
--- a/Makefile.venv
+++ b/Makefile.venv
@@ -89,11 +89,11 @@ endif
 
 VENV=$(VENVDIR)/bin
 EXE=
-ifndef FORCE_UNIX_PATHS
-ifeq ($(OS),Windows_NT)
+#Detect windows
+PLAT=$(shell $(PY) -c "import __future__, sys; print(sys.platform)" )
+ifeq ($(PLAT),win32)
 VENV=$(VENVDIR)/Scripts
 EXE=.exe
-endif
 endif
 
 


### PR DESCRIPTION
Detection of native windows python (the one needing .EXE suffix) is
done now by using python itself