### PR TITLE
Add SETUP_PY documentation to Makefile.venv

### DIFF
--- a/Makefile.venv
+++ b/Makefile.venv
@@ -1,7 +1,7 @@
 #
 # SEAMLESSLY MANAGE PYTHON VIRTUAL ENVIRONMENT WITH A MAKEFILE
 #
-# https://github.com/sio/Makefile.venv             v2022.04.13
+# https://github.com/sio/Makefile.venv             v2022.05.11-dev
 #
 #
 # Insert `include Makefile.venv` at the bottom of your Makefile to enable these

--- a/Makefile.venv
+++ b/Makefile.venv
@@ -42,13 +42,25 @@
 #
 # This Makefile can be configured via following variables:
 #   PY
-#       Command name for system Python interpreter. It is used only initialy to
+#       Command name for system Python interpreter. It is used only initially to
 #       create the virtual environment
 #       Default: python3
 #   REQUIREMENTS_TXT
 #       Space separated list of paths to requirements.txt files.
 #       Paths are resolved relative to current working directory.
 #       Default: requirements.txt
+#
+#       Non-existent files are treated as hard dependencies,
+#       recipes for creating such files must be provided by the main Makefile.
+#       Providing empty value (REQUIREMENTS_TXT=) turns off processing of
+#       requirements.txt even when the file exists.
+#   SETUP_PY
+#       Space separated list of paths to setup.py files.
+#       Corresponding packages will be installed into venv in editable mode
+#       along with all their dependencies
+#       Default: setup.py
+#
+#       Non-existent and empty values are treated in the same way as for REQUIREMENTS_TXT.
 #   WORKDIR
 #       Parent directory for the virtual environment.
 #       Default: current working directory.


### PR DESCRIPTION
Add SETUP_PY documentation to Makefile.venv, as it's missing in the body of the file. 
Thankfully it's present in the README, so copied form there.

Also add more detail to REQUIREMENTS_TXT
And fix nearby typo