### PR TITLE
Define $RM for make -R

### DIFF
--- a/Makefile.venv
+++ b/Makefile.venv
@@ -169,10 +169,11 @@ ifeq (,$(shell command -v touch $(NULL_STDERR)))
 touch=type nul >> $(subst /,\,$(1)) && copy /y /b $(subst /,\,$(1))+,, $(subst /,\,$(1))
 endif
 
+RM?=rm -f
 ifeq (,$(shell command -v $(firstword $(RM)) $(NULL_STDERR)))
-RMDIR=rd /s /q
+RMDIR:=rd /s /q
 else
-RMDIR=$(RM) -r
+RMDIR:=$(RM) -r
 endif
 
 


### PR DESCRIPTION
When make is invoked as `make -R`, then `$(RM)` is not defined.  It is
even worse if the Makefile includes `MAKEFLAGS += R`, which apparently
causes `$(RM)` to be cleared during processing, after the file is
processed even.

In my testing, I found that assigning `$(RMDIR)` using `:=` is enough
when using `MAKEFLAGS` and assigning `$(RM)` to a default value is
necessary when `-R` appears on the command line.  Neither is sufficient
on its own.