### PR TITLE
always call pip through `python -m pip`

### DIFF
--- a/Makefile.venv
+++ b/Makefile.venv
@@ -193,7 +193,7 @@ clean-venv:
 .PHONY: show-venv
 show-venv: venv
 	@$(VENV)/python -c "import sys; print('Python ' + sys.version.replace('\n',''))"
-	@$(VENV)/pip --version
+	@$(VENV)/python -m pip --version
 	@echo venv: $(VENVDIR)
 
 .PHONY: debug-venv
@@ -228,10 +228,10 @@ $(VENV):
 
 $(VENV)/$(MARKER): $(VENVDEPENDS) | $(VENV)
 ifneq ($(strip $(REQUIREMENTS_TXT)),)
-	$(VENV)/pip install $(foreach path,$(REQUIREMENTS_TXT),-r $(path))
+	$(VENV)/python -m install $(foreach path,$(REQUIREMENTS_TXT),-r $(path))
 endif
 ifneq ($(strip $(VENV_LOCAL_PACKAGE)),)
-	$(VENV)/pip install $(foreach path,$(sort $(VENV_LOCAL_PACKAGE)),-e $(dir $(path)))
+	$(VENV)/python -m pip install $(foreach path,$(sort $(VENV_LOCAL_PACKAGE)),-e $(dir $(path)))
 endif
 	$(call touch,$(VENV)/$(MARKER))
 
@@ -268,5 +268,5 @@ $(VENV)/%: $(VENV)/%$(EXE) ;
 endif
 
 $(VENV)/%$(EXE): $(VENV)/$(MARKER)
-	$(VENV)/pip install --upgrade $*
+	$(VENV)/python -m pip install --upgrade $*
 	$(call touch,$@)


### PR DESCRIPTION
It was done in one place, but I thought it would be better to apply it consistently.  It supports python installs that don't have a pip binary.